### PR TITLE
feat (*): custom attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
     "svgr": "svgr -d src/icons/ assets/"
+  },
+  "devDependencies": {
+    "react-test-renderer": "^16.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@svgr/cli": "^4.3.3",
     "clipboard-copy": "^3.1.0",
-    "dedent": "^0.7.0",
     "gh-pages": "^2.1.1",
     "polished": "^3.4.2",
     "react": "^16.2.0",

--- a/src/__snapshots__/character-card.test.js.snap
+++ b/src/__snapshots__/character-card.test.js.snap
@@ -54,49 +54,52 @@ exports[`renders correctly 1`] = `
     </button>
   </div>
   <h1
-    className="sc-cSHVUG fbkGFz"
+    className="sc-fjdhpX bVFrao"
   >
-    <span
-      className="sc-fjdhpX dzfSrA"
-      onClick={[Function]}
+    <div
+      className="sc-kAzzGY iRdAlj"
     >
-      Jai
-    </span>
-     
-    <span
-      className="sc-fjdhpX dzfSrA"
-      onClick={[Function]}
-    />
+      <span
+        className="sc-jTzLTM lfaIdC"
+        onClick={[Function]}
+      >
+        Jai
+      </span>
+       
+      <span
+        className="sc-jTzLTM lfaIdC"
+        onClick={[Function]}
+      />
+      
+    </div>
   </h1>
   <div
-    className="sc-VigVT fSjgWo"
+    className="sc-kAzzGY iRdAlj"
   >
-    A
-     
+    A 
     <span
-      className="sc-fjdhpX dzfSrA"
+      className="sc-jTzLTM lfaIdC"
       onClick={[Function]}
     >
       very old
     </span>
      
     <span
-      className="sc-fjdhpX dzfSrA"
+      className="sc-jTzLTM lfaIdC"
       onClick={[Function]}
     >
       elf
     </span>
      
     <span
-      className="sc-fjdhpX dzfSrA"
+      className="sc-jTzLTM lfaIdC"
       onClick={[Function]}
     >
       man
     </span>
-     
-    of 
+     of 
     <span
-      className="sc-fjdhpX dzfSrA"
+      className="sc-jTzLTM lfaIdC"
       onClick={[Function]}
     >
       Kitharan
@@ -104,19 +107,19 @@ exports[`renders correctly 1`] = `
      descent
   </div>
   <div
-    className="sc-kAzzGY bjYUF"
+    className="sc-jzJRlG iqaRUm"
   >
     <div
-      className="sc-chPdSV gMJsyC"
+      className="sc-cSHVUG MCMkz"
     >
       <div
-        className="sc-VigVT fSjgWo"
+        className="sc-kAzzGY iRdAlj"
       >
         <button
-          className="sc-jTzLTM gYTrtc"
-          onClick={[Function]}
+          className="sc-VigVT ezYRPj"
         >
-          Job 
+          Job
+           
           <svg
             aria-hidden="true"
             className="pen-solid_svg__svg-inline--fa pen-solid_svg__fa-pen pen-solid_svg__fa-w-16"
@@ -131,27 +134,28 @@ exports[`renders correctly 1`] = `
           </svg>
         </button>
         <span
-          className="sc-fjdhpX dzfSrA"
+          className="sc-jTzLTM lfaIdC"
           onClick={[Function]}
         >
           Very talented
         </span>
          
         <span
-          className="sc-fjdhpX dzfSrA"
+          className="sc-jTzLTM lfaIdC"
           onClick={[Function]}
         >
           paladin
         </span>
+        
       </div>
       <div
-        className="sc-VigVT fSjgWo"
+        className="sc-kAzzGY iRdAlj"
       >
         <button
-          className="sc-jTzLTM gYTrtc"
-          onClick={[Function]}
+          className="sc-VigVT ezYRPj"
         >
-          Appearance 
+          Appearance
+           
           <svg
             aria-hidden="true"
             className="pen-solid_svg__svg-inline--fa pen-solid_svg__fa-pen pen-solid_svg__fa-w-16"
@@ -166,32 +170,32 @@ exports[`renders correctly 1`] = `
           </svg>
         </button>
         <span
-          className="sc-fjdhpX dzfSrA"
+          className="sc-jTzLTM lfaIdC"
           onClick={[Function]}
         >
           Athletic
         </span>
-        ,
-         
+        , 
         <span
-          className="sc-fjdhpX dzfSrA"
+          className="sc-jTzLTM lfaIdC"
           onClick={[Function]}
         >
           has several piercings
         </span>
+        
       </div>
     </div>
     <div
-      className="sc-chPdSV gMJsyC"
+      className="sc-cSHVUG MCMkz"
     >
       <div
-        className="sc-VigVT fSjgWo"
+        className="sc-kAzzGY iRdAlj"
       >
         <button
-          className="sc-jTzLTM gYTrtc"
-          onClick={[Function]}
+          className="sc-VigVT ezYRPj"
         >
-          Mood 
+          Mood
+           
           <svg
             aria-hidden="true"
             className="pen-solid_svg__svg-inline--fa pen-solid_svg__fa-pen pen-solid_svg__fa-w-16"
@@ -206,20 +210,21 @@ exports[`renders correctly 1`] = `
           </svg>
         </button>
         <span
-          className="sc-fjdhpX dzfSrA"
+          className="sc-jTzLTM lfaIdC"
           onClick={[Function]}
         >
           Amused
         </span>
+        
       </div>
       <div
-        className="sc-VigVT fSjgWo"
+        className="sc-kAzzGY iRdAlj"
       >
         <button
-          className="sc-jTzLTM gYTrtc"
-          onClick={[Function]}
+          className="sc-VigVT ezYRPj"
         >
-          Personality 
+          Personality
+           
           <svg
             aria-hidden="true"
             className="pen-solid_svg__svg-inline--fa pen-solid_svg__fa-pen pen-solid_svg__fa-w-16"
@@ -234,32 +239,32 @@ exports[`renders correctly 1`] = `
           </svg>
         </button>
         <span
-          className="sc-fjdhpX dzfSrA"
+          className="sc-jTzLTM lfaIdC"
           onClick={[Function]}
         >
           Impulsive
         </span>
-         and
-         
+         and 
         <span
-          className="sc-fjdhpX dzfSrA"
+          className="sc-jTzLTM lfaIdC"
           onClick={[Function]}
         >
           progressive
         </span>
+        
       </div>
     </div>
     <div
-      className="sc-chPdSV gMJsyC"
+      className="sc-cSHVUG MCMkz"
     >
       <div
-        className="sc-VigVT fSjgWo"
+        className="sc-kAzzGY iRdAlj"
       >
         <button
-          className="sc-jTzLTM gYTrtc"
-          onClick={[Function]}
+          className="sc-VigVT ezYRPj"
         >
-          Life goal 
+          Life goal
+           
           <svg
             aria-hidden="true"
             className="pen-solid_svg__svg-inline--fa pen-solid_svg__fa-pen pen-solid_svg__fa-w-16"
@@ -274,20 +279,21 @@ exports[`renders correctly 1`] = `
           </svg>
         </button>
         <span
-          className="sc-fjdhpX dzfSrA"
+          className="sc-jTzLTM lfaIdC"
           onClick={[Function]}
         >
           To teach others
         </span>
+        
       </div>
       <div
-        className="sc-VigVT fSjgWo"
+        className="sc-kAzzGY iRdAlj"
       >
         <button
-          className="sc-jTzLTM gYTrtc"
-          onClick={[Function]}
+          className="sc-VigVT ezYRPj"
         >
-          Relationships 
+          Relationships
+           
           <svg
             aria-hidden="true"
             className="pen-solid_svg__svg-inline--fa pen-solid_svg__fa-pen pen-solid_svg__fa-w-16"
@@ -301,24 +307,20 @@ exports[`renders correctly 1`] = `
             />
           </svg>
         </button>
-        <ul
-          className="sc-jzJRlG dyGPGf"
+        <span
+          className="sc-jTzLTM lfaIdC"
+          onClick={[Function]}
         >
-          <span
-            className="sc-fjdhpX dzfSrA"
-            onClick={[Function]}
-          >
-            Heterosexual
-          </span>
-          ,
-           
-          <span
-            className="sc-fjdhpX dzfSrA"
-            onClick={[Function]}
-          >
-            in a toxic relationship
-          </span>
-        </ul>
+          Heterosexual
+        </span>
+        , 
+        <span
+          className="sc-jTzLTM lfaIdC"
+          onClick={[Function]}
+        >
+          in a toxic relationship
+        </span>
+        
       </div>
     </div>
   </div>

--- a/src/__snapshots__/character-card.test.js.snap
+++ b/src/__snapshots__/character-card.test.js.snap
@@ -1,0 +1,326 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`creates the text description correctly 1`] = `
+"Jai undefined
+A very old elf of Kitharan descent
+Job: very talented paladin
+Appearance: athletic, has several piercings
+Mood: Amused
+Personality: impulsive, progressive
+Life goal: To teach others
+Relationships: heterosexual, in a toxic relationship"
+`;
+
+exports[`renders correctly 1`] = `
+<div
+  className="sc-bwzfXH eIfjiW"
+>
+  <div
+    className="sc-iwsKbI hZghQ"
+  >
+    <button
+      className="sc-htpNat sc-gZMcBi bsNiJL"
+      onClick={[Function]}
+    >
+      <svg
+        aria-hidden="true"
+        className="clipboard-solid_svg__svg-inline--fa clipboard-solid_svg__fa-clipboard clipboard-solid_svg__fa-w-12"
+        data-icon="clipboard"
+        data-prefix="fas"
+        viewBox="0 0 384 512"
+      >
+        <path
+          d="M384 112v352c0 26.51-21.49 48-48 48H48c-26.51 0-48-21.49-48-48V112c0-26.51 21.49-48 48-48h80c0-35.29 28.71-64 64-64s64 28.71 64 64h80c26.51 0 48 21.49 48 48zM192 40c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24m96 114v-20a6 6 0 00-6-6H102a6 6 0 00-6 6v20a6 6 0 006 6h180a6 6 0 006-6z"
+          fill="currentColor"
+        />
+      </svg>
+    </button>
+    <button
+      className="sc-htpNat sc-gZMcBi bsNiJL"
+      onClick={[Function]}
+    >
+      <svg
+        aria-hidden="true"
+        className="trash-solid_svg__svg-inline--fa trash-solid_svg__fa-trash trash-solid_svg__fa-w-14"
+        data-icon="trash"
+        data-prefix="fas"
+        viewBox="0 0 448 512"
+      >
+        <path
+          d="M432 32H312l-9.4-18.7A24 24 0 00281.1 0H166.8a23.72 23.72 0 00-21.4 13.3L136 32H16A16 16 0 000 48v32a16 16 0 0016 16h416a16 16 0 0016-16V48a16 16 0 00-16-16zM53.2 467a48 48 0 0047.9 45h245.8a48 48 0 0047.9-45L416 128H32z"
+          fill="currentColor"
+        />
+      </svg>
+    </button>
+  </div>
+  <h1
+    className="sc-cSHVUG fbkGFz"
+  >
+    <span
+      className="sc-fjdhpX dzfSrA"
+      onClick={[Function]}
+    >
+      Jai
+    </span>
+     
+    <span
+      className="sc-fjdhpX dzfSrA"
+      onClick={[Function]}
+    />
+  </h1>
+  <div
+    className="sc-VigVT fSjgWo"
+  >
+    A
+     
+    <span
+      className="sc-fjdhpX dzfSrA"
+      onClick={[Function]}
+    >
+      very old
+    </span>
+     
+    <span
+      className="sc-fjdhpX dzfSrA"
+      onClick={[Function]}
+    >
+      elf
+    </span>
+     
+    <span
+      className="sc-fjdhpX dzfSrA"
+      onClick={[Function]}
+    >
+      man
+    </span>
+     
+    of 
+    <span
+      className="sc-fjdhpX dzfSrA"
+      onClick={[Function]}
+    >
+      Kitharan
+    </span>
+     descent
+  </div>
+  <div
+    className="sc-kAzzGY bjYUF"
+  >
+    <div
+      className="sc-chPdSV gMJsyC"
+    >
+      <div
+        className="sc-VigVT fSjgWo"
+      >
+        <button
+          className="sc-jTzLTM gYTrtc"
+          onClick={[Function]}
+        >
+          Job 
+          <svg
+            aria-hidden="true"
+            className="pen-solid_svg__svg-inline--fa pen-solid_svg__fa-pen pen-solid_svg__fa-w-16"
+            data-icon="pen"
+            data-prefix="fas"
+            viewBox="0 0 512 512"
+          >
+            <path
+              d="M290.74 93.24l128.02 128.02-277.99 277.99-114.14 12.6C11.35 513.54-1.56 500.62.14 485.34l12.7-114.22 277.9-277.88zm207.2-19.06l-60.11-60.11c-18.75-18.75-49.16-18.75-67.91 0l-56.55 56.55 128.02 128.02 56.55-56.55c18.75-18.76 18.75-49.16 0-67.91z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <span
+          className="sc-fjdhpX dzfSrA"
+          onClick={[Function]}
+        >
+          Very talented
+        </span>
+         
+        <span
+          className="sc-fjdhpX dzfSrA"
+          onClick={[Function]}
+        >
+          paladin
+        </span>
+      </div>
+      <div
+        className="sc-VigVT fSjgWo"
+      >
+        <button
+          className="sc-jTzLTM gYTrtc"
+          onClick={[Function]}
+        >
+          Appearance 
+          <svg
+            aria-hidden="true"
+            className="pen-solid_svg__svg-inline--fa pen-solid_svg__fa-pen pen-solid_svg__fa-w-16"
+            data-icon="pen"
+            data-prefix="fas"
+            viewBox="0 0 512 512"
+          >
+            <path
+              d="M290.74 93.24l128.02 128.02-277.99 277.99-114.14 12.6C11.35 513.54-1.56 500.62.14 485.34l12.7-114.22 277.9-277.88zm207.2-19.06l-60.11-60.11c-18.75-18.75-49.16-18.75-67.91 0l-56.55 56.55 128.02 128.02 56.55-56.55c18.75-18.76 18.75-49.16 0-67.91z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <span
+          className="sc-fjdhpX dzfSrA"
+          onClick={[Function]}
+        >
+          Athletic
+        </span>
+        ,
+         
+        <span
+          className="sc-fjdhpX dzfSrA"
+          onClick={[Function]}
+        >
+          has several piercings
+        </span>
+      </div>
+    </div>
+    <div
+      className="sc-chPdSV gMJsyC"
+    >
+      <div
+        className="sc-VigVT fSjgWo"
+      >
+        <button
+          className="sc-jTzLTM gYTrtc"
+          onClick={[Function]}
+        >
+          Mood 
+          <svg
+            aria-hidden="true"
+            className="pen-solid_svg__svg-inline--fa pen-solid_svg__fa-pen pen-solid_svg__fa-w-16"
+            data-icon="pen"
+            data-prefix="fas"
+            viewBox="0 0 512 512"
+          >
+            <path
+              d="M290.74 93.24l128.02 128.02-277.99 277.99-114.14 12.6C11.35 513.54-1.56 500.62.14 485.34l12.7-114.22 277.9-277.88zm207.2-19.06l-60.11-60.11c-18.75-18.75-49.16-18.75-67.91 0l-56.55 56.55 128.02 128.02 56.55-56.55c18.75-18.76 18.75-49.16 0-67.91z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <span
+          className="sc-fjdhpX dzfSrA"
+          onClick={[Function]}
+        >
+          Amused
+        </span>
+      </div>
+      <div
+        className="sc-VigVT fSjgWo"
+      >
+        <button
+          className="sc-jTzLTM gYTrtc"
+          onClick={[Function]}
+        >
+          Personality 
+          <svg
+            aria-hidden="true"
+            className="pen-solid_svg__svg-inline--fa pen-solid_svg__fa-pen pen-solid_svg__fa-w-16"
+            data-icon="pen"
+            data-prefix="fas"
+            viewBox="0 0 512 512"
+          >
+            <path
+              d="M290.74 93.24l128.02 128.02-277.99 277.99-114.14 12.6C11.35 513.54-1.56 500.62.14 485.34l12.7-114.22 277.9-277.88zm207.2-19.06l-60.11-60.11c-18.75-18.75-49.16-18.75-67.91 0l-56.55 56.55 128.02 128.02 56.55-56.55c18.75-18.76 18.75-49.16 0-67.91z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <span
+          className="sc-fjdhpX dzfSrA"
+          onClick={[Function]}
+        >
+          Impulsive
+        </span>
+         and
+         
+        <span
+          className="sc-fjdhpX dzfSrA"
+          onClick={[Function]}
+        >
+          progressive
+        </span>
+      </div>
+    </div>
+    <div
+      className="sc-chPdSV gMJsyC"
+    >
+      <div
+        className="sc-VigVT fSjgWo"
+      >
+        <button
+          className="sc-jTzLTM gYTrtc"
+          onClick={[Function]}
+        >
+          Life goal 
+          <svg
+            aria-hidden="true"
+            className="pen-solid_svg__svg-inline--fa pen-solid_svg__fa-pen pen-solid_svg__fa-w-16"
+            data-icon="pen"
+            data-prefix="fas"
+            viewBox="0 0 512 512"
+          >
+            <path
+              d="M290.74 93.24l128.02 128.02-277.99 277.99-114.14 12.6C11.35 513.54-1.56 500.62.14 485.34l12.7-114.22 277.9-277.88zm207.2-19.06l-60.11-60.11c-18.75-18.75-49.16-18.75-67.91 0l-56.55 56.55 128.02 128.02 56.55-56.55c18.75-18.76 18.75-49.16 0-67.91z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <span
+          className="sc-fjdhpX dzfSrA"
+          onClick={[Function]}
+        >
+          To teach others
+        </span>
+      </div>
+      <div
+        className="sc-VigVT fSjgWo"
+      >
+        <button
+          className="sc-jTzLTM gYTrtc"
+          onClick={[Function]}
+        >
+          Relationships 
+          <svg
+            aria-hidden="true"
+            className="pen-solid_svg__svg-inline--fa pen-solid_svg__fa-pen pen-solid_svg__fa-w-16"
+            data-icon="pen"
+            data-prefix="fas"
+            viewBox="0 0 512 512"
+          >
+            <path
+              d="M290.74 93.24l128.02 128.02-277.99 277.99-114.14 12.6C11.35 513.54-1.56 500.62.14 485.34l12.7-114.22 277.9-277.88zm207.2-19.06l-60.11-60.11c-18.75-18.75-49.16-18.75-67.91 0l-56.55 56.55 128.02 128.02 56.55-56.55c18.75-18.76 18.75-49.16 0-67.91z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <ul
+          className="sc-jzJRlG dyGPGf"
+        >
+          <span
+            className="sc-fjdhpX dzfSrA"
+            onClick={[Function]}
+          >
+            Heterosexual
+          </span>
+          ,
+           
+          <span
+            className="sc-fjdhpX dzfSrA"
+            onClick={[Function]}
+          >
+            in a toxic relationship
+          </span>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/__snapshots__/character-card.test.js.snap
+++ b/src/__snapshots__/character-card.test.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`creates the text description correctly 1`] = `
-"Jai undefined
-A very old elf of Kitharan descent
-Job: very talented paladin
-Appearance: athletic, has several piercings
+"Jai 
+A very old elf man of Kitharan descent
+Job: Very talented paladin
+Appearance: Athletic, has several piercings
 Mood: Amused
-Personality: impulsive, progressive
+Personality: Impulsive, progressive
 Life goal: To teach others
-Relationships: heterosexual, in a toxic relationship"
+Relationships: Heterosexual, in a toxic relationship"
 `;
 
 exports[`renders correctly 1`] = `
@@ -54,52 +54,44 @@ exports[`renders correctly 1`] = `
     </button>
   </div>
   <h1
-    className="sc-fjdhpX bVFrao"
+    className="sc-jTzLTM iVgTwl"
   >
     <div
-      className="sc-kAzzGY iRdAlj"
+      className="sc-cSHVUG bFFreH"
     >
       <span
-        className="sc-jTzLTM lfaIdC"
+        className="sc-kAzzGY kxJWRz"
         onClick={[Function]}
       >
         Jai
       </span>
        
-      <span
-        className="sc-jTzLTM lfaIdC"
-        onClick={[Function]}
-      />
       
     </div>
   </h1>
   <div
-    className="sc-kAzzGY iRdAlj"
+    className="sc-cSHVUG bFFreH"
   >
-    A 
+    A
+     
     <span
-      className="sc-jTzLTM lfaIdC"
+      className="sc-kAzzGY kxJWRz"
       onClick={[Function]}
     >
       very old
     </span>
      
     <span
-      className="sc-jTzLTM lfaIdC"
+      className="sc-kAzzGY kxJWRz"
       onClick={[Function]}
     >
       elf
     </span>
      
-    <span
-      className="sc-jTzLTM lfaIdC"
-      onClick={[Function]}
-    >
-      man
-    </span>
+    man
      of 
     <span
-      className="sc-jTzLTM lfaIdC"
+      className="sc-kAzzGY kxJWRz"
       onClick={[Function]}
     >
       Kitharan
@@ -107,24 +99,25 @@ exports[`renders correctly 1`] = `
      descent
   </div>
   <div
-    className="sc-jzJRlG iqaRUm"
+    className="sc-fjdhpX iYnJBp"
   >
     <div
-      className="sc-cSHVUG MCMkz"
+      className="sc-jzJRlG jBoRzS"
     >
       <div
-        className="sc-kAzzGY iRdAlj"
+        className="sc-cSHVUG bFFreH"
       >
         <button
           className="sc-VigVT ezYRPj"
         >
-          Job
+          job
            
           <svg
             aria-hidden="true"
             className="pen-solid_svg__svg-inline--fa pen-solid_svg__fa-pen pen-solid_svg__fa-w-16"
             data-icon="pen"
             data-prefix="fas"
+            onClick={[Function]}
             viewBox="0 0 512 512"
           >
             <path
@@ -134,33 +127,33 @@ exports[`renders correctly 1`] = `
           </svg>
         </button>
         <span
-          className="sc-jTzLTM lfaIdC"
+          className="sc-kAzzGY kxJWRz"
           onClick={[Function]}
         >
           Very talented
         </span>
          
         <span
-          className="sc-jTzLTM lfaIdC"
+          className="sc-kAzzGY kxJWRz"
           onClick={[Function]}
         >
           paladin
         </span>
-        
       </div>
       <div
-        className="sc-kAzzGY iRdAlj"
+        className="sc-cSHVUG bFFreH"
       >
         <button
           className="sc-VigVT ezYRPj"
         >
-          Appearance
+          appearance
            
           <svg
             aria-hidden="true"
             className="pen-solid_svg__svg-inline--fa pen-solid_svg__fa-pen pen-solid_svg__fa-w-16"
             data-icon="pen"
             data-prefix="fas"
+            onClick={[Function]}
             viewBox="0 0 512 512"
           >
             <path
@@ -170,37 +163,37 @@ exports[`renders correctly 1`] = `
           </svg>
         </button>
         <span
-          className="sc-jTzLTM lfaIdC"
+          className="sc-kAzzGY kxJWRz"
           onClick={[Function]}
         >
           Athletic
         </span>
         , 
         <span
-          className="sc-jTzLTM lfaIdC"
+          className="sc-kAzzGY kxJWRz"
           onClick={[Function]}
         >
           has several piercings
         </span>
-        
       </div>
     </div>
     <div
-      className="sc-cSHVUG MCMkz"
+      className="sc-jzJRlG jBoRzS"
     >
       <div
-        className="sc-kAzzGY iRdAlj"
+        className="sc-cSHVUG bFFreH"
       >
         <button
           className="sc-VigVT ezYRPj"
         >
-          Mood
+          mood
            
           <svg
             aria-hidden="true"
             className="pen-solid_svg__svg-inline--fa pen-solid_svg__fa-pen pen-solid_svg__fa-w-16"
             data-icon="pen"
             data-prefix="fas"
+            onClick={[Function]}
             viewBox="0 0 512 512"
           >
             <path
@@ -210,26 +203,26 @@ exports[`renders correctly 1`] = `
           </svg>
         </button>
         <span
-          className="sc-jTzLTM lfaIdC"
+          className="sc-kAzzGY kxJWRz"
           onClick={[Function]}
         >
           Amused
         </span>
-        
       </div>
       <div
-        className="sc-kAzzGY iRdAlj"
+        className="sc-cSHVUG bFFreH"
       >
         <button
           className="sc-VigVT ezYRPj"
         >
-          Personality
+          personality
            
           <svg
             aria-hidden="true"
             className="pen-solid_svg__svg-inline--fa pen-solid_svg__fa-pen pen-solid_svg__fa-w-16"
             data-icon="pen"
             data-prefix="fas"
+            onClick={[Function]}
             viewBox="0 0 512 512"
           >
             <path
@@ -239,37 +232,37 @@ exports[`renders correctly 1`] = `
           </svg>
         </button>
         <span
-          className="sc-jTzLTM lfaIdC"
+          className="sc-kAzzGY kxJWRz"
           onClick={[Function]}
         >
           Impulsive
         </span>
-         and 
+        , 
         <span
-          className="sc-jTzLTM lfaIdC"
+          className="sc-kAzzGY kxJWRz"
           onClick={[Function]}
         >
           progressive
         </span>
-        
       </div>
     </div>
     <div
-      className="sc-cSHVUG MCMkz"
+      className="sc-jzJRlG jBoRzS"
     >
       <div
-        className="sc-kAzzGY iRdAlj"
+        className="sc-cSHVUG bFFreH"
       >
         <button
           className="sc-VigVT ezYRPj"
         >
-          Life goal
+          life goal
            
           <svg
             aria-hidden="true"
             className="pen-solid_svg__svg-inline--fa pen-solid_svg__fa-pen pen-solid_svg__fa-w-16"
             data-icon="pen"
             data-prefix="fas"
+            onClick={[Function]}
             viewBox="0 0 512 512"
           >
             <path
@@ -279,26 +272,26 @@ exports[`renders correctly 1`] = `
           </svg>
         </button>
         <span
-          className="sc-jTzLTM lfaIdC"
+          className="sc-kAzzGY kxJWRz"
           onClick={[Function]}
         >
           To teach others
         </span>
-        
       </div>
       <div
-        className="sc-kAzzGY iRdAlj"
+        className="sc-cSHVUG bFFreH"
       >
         <button
           className="sc-VigVT ezYRPj"
         >
-          Relationships
+          relationships
            
           <svg
             aria-hidden="true"
             className="pen-solid_svg__svg-inline--fa pen-solid_svg__fa-pen pen-solid_svg__fa-w-16"
             data-icon="pen"
             data-prefix="fas"
+            onClick={[Function]}
             viewBox="0 0 512 512"
           >
             <path
@@ -308,19 +301,18 @@ exports[`renders correctly 1`] = `
           </svg>
         </button>
         <span
-          className="sc-jTzLTM lfaIdC"
+          className="sc-kAzzGY kxJWRz"
           onClick={[Function]}
         >
           Heterosexual
         </span>
         , 
         <span
-          className="sc-jTzLTM lfaIdC"
+          className="sc-kAzzGY kxJWRz"
           onClick={[Function]}
         >
           in a toxic relationship
         </span>
-        
       </div>
     </div>
   </div>

--- a/src/attribute-configs.js
+++ b/src/attribute-configs.js
@@ -1,3 +1,12 @@
+/**
+ * Configs that describe how to turn character attributes into human-readable
+ * sentences.
+ * A js Map was used, because it's an iterable and a key-value store
+ * at the same time.
+ * If the need for i18n arises, create separate attributeConfigs for each
+ * language.
+ */
+
 export const attributeConfigs = new Map([
     ['name', {
         template: '%givenName% %familyName%'

--- a/src/attribute-configs.js
+++ b/src/attribute-configs.js
@@ -1,0 +1,32 @@
+export const attributeConfigs = new Map([
+    ['name', {
+        template: '%givenName% %familyName%'
+    }],
+    ['description', {
+        template: '%INDEFINITE_ARTICLE% %age% %race% %gender% of %ancestry% descent',
+    }],
+    ['job', {
+        template: '%competency% %job%',
+        label: 'job' 
+    }],
+    ['appearance', {
+        template: '%appearance1%, %appearance2%',
+        label: 'appearance' 
+    }],
+    ['mood', {
+        template: '%mood%',
+        label: 'mood' 
+    }],
+    ['personality', {
+        template: '%personality1%, %personality2%',
+        label: 'personality' 
+    }],
+    ['lifeGoal', {
+        template: '%motivation%',
+        label: 'life goal' 
+    }],
+    ['relationships', {
+        template: '%sexuality%, %relationship%',
+        label: 'relationships'
+    }]
+]);

--- a/src/character-card.js
+++ b/src/character-card.js
@@ -1,0 +1,139 @@
+import React from 'react';
+
+import dedent from 'dedent';
+import copy from 'clipboard-copy';
+
+import ClipboardSolid from './icons/ClipboardSolid';
+import PenSolid from './icons/PenSolid';
+import TrashSolid from './icons/TrashSolid';
+
+import {
+    AttributeGroup,
+    AttributeGroupLabel,
+    AttributeList,
+    AttributeLabel,
+    CharacterCardColumn,
+    CharacterCardContainer,
+    CharacterCardRow,
+    CharacterCardToolbar,
+    NameWrapper,
+    ToolbarButton
+} from './styles.js';
+
+const uppercaseFirstLetter = (string) => {
+    return string
+        ? string.charAt(0).toUpperCase() + string.slice(1)
+        : false;
+}
+
+const determinerBefore = (string) => {
+    return ['a', 'e', 'i', 'o', 'u'].includes(string.charAt(0)) ? 'an' : 'a';
+}
+
+const displayGender = (age, gender) => {
+    switch (gender) {
+        case 'cis male': return ['young', 'teenage'].includes(age) ? 'boy' : 'man';
+        case 'cis female': return ['young', 'teenage'].includes(age) ? 'girl' : 'woman';
+        case 'trans male': return ['young', 'teenage'].includes(age) ? 'trans boy' : 'trans man';
+        case 'trans female': return ['young', 'teenage'].includes(age) ? 'trans girl' : 'trans woman';
+        case 'genderfluid': return ['young', 'teenage'].includes(age) ? 'genderfluid child' : 'genderfluid person';
+        case 'agender': return ['young', 'teenage'].includes(age) ? 'agender child' : 'agender person';
+        default: return 'person';
+    }
+}
+
+export const createTextDescription = (character) => dedent(
+    `${character.givenName.text} ${character.familyName.text}
+    ${uppercaseFirstLetter(determinerBefore(character.age.text))} ${character.age.text} ${character.race.text} of ${character.ancestry.text} descent
+    Job: ${character.competency.text} ${character.job.text}
+    Appearance: ${character.appearance1.text}, ${character.appearance2.text}
+    Mood: ${character.mood.text}
+    Personality: ${character.personality1.text}, ${character.personality2.text}
+    Life goal: ${character.motivation.text}
+    Relationships: ${character.sexuality.text}, ${character.relationship.text}`
+)
+
+const Attribute = (props) => {
+    return (
+        <AttributeLabel onClick={props.onClick}>{props.value}</AttributeLabel>
+    );
+}
+
+export const CharacterCard = ({
+    deleteCharacter,
+    reshuffle,
+    character,
+    isAttributeGroupBeingEdited,
+    setAttributeGroupBeingEdited
+}) => {
+    return (
+        <CharacterCardContainer>
+            <CharacterCardToolbar>
+                <ToolbarButton onClick={() => copy(createTextDescription(character))}>
+                    <ClipboardSolid />
+                </ToolbarButton>
+                <ToolbarButton onClick={() => deleteCharacter()}>
+                    <TrashSolid />
+                </ToolbarButton>
+            </CharacterCardToolbar>
+            <NameWrapper>
+                <Attribute name='givenName' onClick={() => reshuffle('givenName')} value={character.givenName.text} />
+                {' '}
+                <Attribute name='familyName' onClick={() => reshuffle('familyName')} value={character.familyName.text} />
+            </NameWrapper>
+            <AttributeGroup>
+                {uppercaseFirstLetter(determinerBefore(character.age.text))}
+                {' '}
+                <Attribute name='age' onClick={() => reshuffle('age')} value={character.age.text} />
+                {' '}
+                <Attribute name='race' onClick={() => reshuffle('race')} value={character.race.text} />
+                {' '}
+                <Attribute name='gender' onClick={() => reshuffle('gender')} value={displayGender(character.age.text, character.gender.text)} />
+                {' '}
+                of <Attribute name='ancestry' onClick={() => reshuffle('ancestry')} value={character.ancestry.text} /> descent
+            </AttributeGroup>
+            <CharacterCardRow>
+                <CharacterCardColumn>
+                    <AttributeGroup isBeingEdited={isAttributeGroupBeingEdited('job')}>
+                        <AttributeGroupLabel onClick={() => setAttributeGroupBeingEdited('job')}>Job <PenSolid /></AttributeGroupLabel>
+                        <Attribute name='competency' onClick={() => reshuffle('competency')} value={uppercaseFirstLetter(character.competency.text)} />
+                        {' '}
+                        <Attribute name='job' onClick={() => reshuffle('job')} value={character.job.text} />
+                    </AttributeGroup>
+                    <AttributeGroup isBeingEdited={isAttributeGroupBeingEdited('appearance')}>
+                        <AttributeGroupLabel onClick={() => setAttributeGroupBeingEdited('appearance')}>Appearance <PenSolid /></AttributeGroupLabel>
+                        <Attribute name='appearance1' onClick={() => reshuffle('appearance1')} value={uppercaseFirstLetter(character.appearance1.text)} />,
+                        {' '}
+                        <Attribute name='appearance2' onClick={() => reshuffle('appearance2')} value={character.appearance2.text} />
+                    </AttributeGroup>
+                </CharacterCardColumn>
+                <CharacterCardColumn>
+                    <AttributeGroup isBeingEdited={isAttributeGroupBeingEdited('mood')}>
+                        <AttributeGroupLabel onClick={() => setAttributeGroupBeingEdited('mood')}>Mood <PenSolid /></AttributeGroupLabel>
+                        <Attribute name='mood' onClick={() => reshuffle('mood')} value={character.mood.text} />
+                    </AttributeGroup>
+                    <AttributeGroup isBeingEdited={isAttributeGroupBeingEdited('personality')}>
+                        <AttributeGroupLabel onClick={() => setAttributeGroupBeingEdited('personality')}>Personality <PenSolid /></AttributeGroupLabel>
+                        <Attribute name='personality1' onClick={() => reshuffle('personality1')} value={uppercaseFirstLetter(character.personality1.text)} /> and
+                        {' '}
+                        <Attribute name='personality2' onClick={() => reshuffle('personality2')} value={character.personality2.text} />
+                    </AttributeGroup>
+                </CharacterCardColumn>
+                <CharacterCardColumn>
+                    <AttributeGroup isBeingEdited={isAttributeGroupBeingEdited('motivation')}>
+                        <AttributeGroupLabel onClick={() => setAttributeGroupBeingEdited('motivation')}>Life goal <PenSolid /></AttributeGroupLabel>
+                        <Attribute name='motivation' onClick={() => reshuffle('motivation')} value={character.motivation.text} />
+                    </AttributeGroup>
+                    <AttributeGroup isBeingEdited={isAttributeGroupBeingEdited('relationships')}>
+                        <AttributeGroupLabel onClick={() => setAttributeGroupBeingEdited('relationships')}>Relationships <PenSolid /></AttributeGroupLabel>
+                        <AttributeList>
+                            <Attribute name='sexuality' onClick={() => reshuffle('sexuality')} value={uppercaseFirstLetter(character.sexuality.text)} />,
+                            {' '}
+                            <Attribute name='relationship' onClick={() => reshuffle('relationship')} value={character.relationship.text} />
+                        </AttributeList>
+                    </AttributeGroup>
+                </CharacterCardColumn>
+            </CharacterCardRow>
+        </CharacterCardContainer>
+    )
+}

--- a/src/character-card.js
+++ b/src/character-card.js
@@ -6,7 +6,6 @@ import React, {
 } from 'react';
 import styled from 'styled-components';
 
-import dedent from 'dedent';
 import copy from 'clipboard-copy';
 
 import ClipboardSolid from './icons/ClipboardSolid';

--- a/src/character-card.js
+++ b/src/character-card.js
@@ -58,6 +58,19 @@ export const ClickableAttribute = styled.span`
 
 export const EditableAttributes = styled.span``;
 
+/**
+ * A hackjob of a template parser, that knows a bit of grammar.
+ * Converts templates into a format that can be rendered as text, html,
+ * or anything else if the need arises.
+ * Templates are plain strings.
+ * Anything between %% delimiters will be replaced by the corresponding
+ * value from the `values` object passed.
+ * %INDEFINITE_ARTICLE% will be replaced with the proper article for the
+ * word following it.
+ * If any other grammar issues arise (pronouns, etc.) they can be solved here.
+ * If the need for i18n arises, grammar rules should probably be pluggable,
+ * and different for each language.
+ */
 const parseTemplate = ({
     template,
     values
@@ -93,6 +106,9 @@ const parseTemplate = ({
         : [[capitalize(first[0]), first[1]], ...rest]
 }
 
+/**
+ * A react component that renders the output of `parseTemplate` as HTML.
+ */
 const GeneratedAttributes = ({
     template,
     values,
@@ -116,7 +132,10 @@ const GeneratedAttributes = ({
             }
         })
 
-const attributesFromTemplate = ({
+/**
+ * A function that renders the output of `parseTemplate` as plain text.
+ */        
+const generatedAttributes = ({
     template,
     values
 }) =>
@@ -133,7 +152,7 @@ export const createTextDescription = ({
             ([id, { label, template }]) => {
                 const description = values.customAttributes[id]
                     ? values.customAttributes[id]
-                    : attributesFromTemplate({ template, values })
+                    : generatedAttributes({ template, values })
                 return `${label ? `${capitalize(label)}: ` : ''}${description}`
             }
         )
@@ -160,7 +179,7 @@ const AttributeGroup = ({
     })
 
     const switchToCustomAttributes = () => {
-        setCustomAttribute(id, attributesFromTemplate({ template, values }));
+        setCustomAttribute(id, generatedAttributes({ template, values }));
         setEditMode(true);
     };
 
@@ -170,18 +189,15 @@ const AttributeGroup = ({
     };
 
     const customAttribute = values.customAttributes[id];
-    const hasCustomAttribute = customAttribute === ''
-        ? true
-        : Boolean(customAttribute);
 
     return (
         <AttributeGroupWrapper>
             {label &&
                 <AttributeGroupLabel>
-                    {label} {!hasCustomAttribute &&<PenSolid onClick={switchToCustomAttributes} />}
+                    {label} {!customAttribute &&<PenSolid onClick={switchToCustomAttributes} />}
                 </AttributeGroupLabel>
             }
-            {hasCustomAttribute
+            {customAttribute
                 ? <EditableAttributes
                     contentEditable={true}
                     onBlur={changeHandler} // TODO: better change handling

--- a/src/character-card.js
+++ b/src/character-card.js
@@ -1,5 +1,7 @@
 import React, {
     Fragment,
+    useState,
+    useEffect,
     useRef
 } from 'react';
 import styled from 'styled-components';
@@ -144,10 +146,23 @@ const AttributeGroup = ({
 }) => {
     
     const editableElement = useRef(null);
-    
-    const switchToCustomAttributes = () => setCustomAttribute(id, attributesFromTemplate({ template, values }));
-    const switchToGeneratedAttributes = () => setCustomAttribute(id, false);
-    const changeHandler = () => setCustomAttribute(id, editableElement.current.innerHTML);
+    const [editMode, setEditMode] = useState(false);
+
+    useEffect(() => {
+        if (editMode && editableElement.current) {
+            editableElement.current.focus();
+        }
+    })
+
+    const switchToCustomAttributes = () => {
+        setCustomAttribute(id, attributesFromTemplate({ template, values }));
+        setEditMode(true);
+    };
+
+    const changeHandler = () => {
+        setCustomAttribute(id, editableElement.current.innerHTML)
+        setEditMode(false);
+    };
 
     const customAttribute = values.customAttributes[id];
     const hasCustomAttribute = customAttribute === ''
@@ -158,10 +173,7 @@ const AttributeGroup = ({
         <AttributeGroupWrapper>
             {label &&
                 <AttributeGroupLabel>
-                    {label} {hasCustomAttribute
-                        ? <span onClick={switchToGeneratedAttributes}>R</span> // TODO: UX change or an icon is needed
-                        : <PenSolid onClick={switchToCustomAttributes} />
-                    }
+                    {label} {!hasCustomAttribute &&<PenSolid onClick={switchToCustomAttributes} />}
                 </AttributeGroupLabel>
             }
             {hasCustomAttribute

--- a/src/character-card.js
+++ b/src/character-card.js
@@ -65,15 +65,22 @@ const compileTemplate = ({
         .split('%')
         .filter(string => string !== '')
         .reduceRight((acc, token) => {
+            // edge case
             if (token === 'gender') {
                 return [displayGender(values.age.text, values.gender.text), ...acc]
-            } else if (values[token]) {
+            // a value exists
+            } else if (values[token] && values[token].text) {
                 return [[values[token].text, token], ...acc]
+            // a value exists, but is empty
+            } else if (values[token] === false) { // null would be a better choice
+                return ['', ...acc]
+            // other special cases
             } else if (token === 'INDEFINITE_ARTICLE') {
                 const firstNonWhitespace = acc.find(e => e !== ' ')
                 return Array.isArray(firstNonWhitespace)
                     ? [indefiniteArticleFor(firstNonWhitespace[0]), ...acc]
                     : [indefiniteArticleFor(firstNonWhitespace), ...acc]
+            // plain text
             } else {
                 return [token, ...acc]
             }
@@ -133,10 +140,10 @@ export const CharacterCard = ({
 }) => {
 
     const attributeTemplates = new Map([
-        ['name', '%givenName% %familyName'],
+        ['name', '%givenName% %familyName%'],
         ['description', '%INDEFINITE_ARTICLE% %age% %race% %gender% of %ancestry% descent'],
         ['job', '%competency% %job%'],
-        ['appearance', '%appearance1%, %appearance2'],
+        ['appearance', '%appearance1%, %appearance2%'],
         ['mood', '%mood%'],
         ['personality', '%personality1% and %personality2%'],
         ['life goal', '%motivation%'],

--- a/src/character-card.js
+++ b/src/character-card.js
@@ -58,11 +58,12 @@ export const ClickableAttribute = styled.span`
 
 export const EditableAttributes = styled.span``;
 
-const compileTemplate = ({
+const parseTemplate = ({
     template,
     values
-}) =>
-    template
+}) => {
+
+    const [first, ...rest] = template
         .split('%')
         .filter(string => string !== '')
         .reduceRight((acc, token) => {
@@ -87,12 +88,17 @@ const compileTemplate = ({
             }
         }, [])
 
+    return typeof first === 'string'
+        ? [capitalize(first), ...rest]
+        : [[capitalize(first[0]), first[1]], ...rest]
+}
+
 const GeneratedAttributes = ({
     template,
     values,
     reshuffleAttribute
 }) =>
-    compileTemplate({ template, values })
+    parseTemplate({ template, values })
         .map(e => {
             if (Array.isArray(e)) {
                 const [value, key] = e;
@@ -114,7 +120,7 @@ const attributesFromTemplate = ({
     template,
     values
 }) =>
-    compileTemplate({ template, values })
+    parseTemplate({ template, values })
         .map(e => Array.isArray(e) ? e[0] : e)
         .join('')
 
@@ -128,7 +134,7 @@ export const createTextDescription = ({
                 const description = values.customAttributes[id]
                     ? values.customAttributes[id]
                     : attributesFromTemplate({ template, values })
-                return `${label ? `${capitalize(label)}: ` : ''}${capitalize(description)}`
+                return `${label ? `${capitalize(label)}: ` : ''}${description}`
             }
         )
         .join('\n')

--- a/src/character-card.test.js
+++ b/src/character-card.test.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+
+import {
+    CharacterCard,
+    createTextDescription
+} from './character-card.js'
+
+const character = {
+    "gender": {
+        "text": "cis male"
+    },
+    "ancestry": {
+        "text": "Kitharan"
+    },
+    "age": {
+        "text": "very old"
+    },
+    "motivation": {
+        "text": "To teach others"
+    },
+    "mood": {
+        "text": "Amused"
+    },
+    "appearance1": {
+        "text": "athletic",
+        "tags": [
+            "build"
+        ]
+    },
+    "personality1": {
+        "text": "impulsive",
+        "tags": [
+            "impulsiveness"
+        ]
+    },
+    "competency": {
+        "text": "very talented"
+    },
+    "job": {
+        "text": "paladin"
+    },
+    "sexuality": {
+        "text": "heterosexual"
+    },
+    "givenName": {
+        "text": "Jai"
+    },
+    "familyName": false,
+    "race": {
+        "text": "elf"
+    },
+    "relationship": {
+        "text": "in a toxic relationship"
+    },
+    "appearance2": {
+        "text": "has several piercings",
+        "tags": [
+            "jewelry"
+        ]
+    },
+    "personality2": {
+        "text": "progressive",
+        "tags": [
+            "progressiveness"
+        ]
+    }
+}
+
+const props = {
+    deleteCharacter: () => undefined,
+    reshuffle: () => undefined,
+    character,
+    isAttributeGroupBeingEdited: () => false,
+    setAttributeGroupBeingEdited: () => undefined
+}
+
+it('renders correctly', () => {
+    const tree = TestRenderer
+        .create(<CharacterCard {...props} />)
+        .toJSON();
+    expect(tree).toMatchSnapshot();
+})
+
+it('creates the text description correctly',  () => {
+    const text = createTextDescription(character);
+    expect(text).toMatchSnapshot();
+})

--- a/src/character-card.test.js
+++ b/src/character-card.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 
+import { attributeConfigs } from './attribute-configs'
+
 import {
     CharacterCard,
     createTextDescription
@@ -64,15 +66,17 @@ const character = {
         "tags": [
             "progressiveness"
         ]
+    },
+    "customAttributes": {
     }
 }
 
 const props = {
     deleteCharacter: () => undefined,
-    reshuffle: () => undefined,
+    reshuffleAttribute: () => undefined,
+    setCustomAttribute: () => undefined,
     character,
-    isAttributeGroupBeingEdited: () => false,
-    setAttributeGroupBeingEdited: () => undefined
+    attributeConfigs
 }
 
 it('renders correctly', () => {
@@ -83,6 +87,6 @@ it('renders correctly', () => {
 })
 
 it('creates the text description correctly',  () => {
-    const text = createTextDescription(character);
+    const text = createTextDescription({ attributeConfigs, values: character });
     expect(text).toMatchSnapshot();
 })

--- a/src/character.js
+++ b/src/character.js
@@ -113,7 +113,7 @@ export const setCustomAttribute = (character, customAttributeKey, customAttribut
     }
 }
 
-export const reshuffle = (worldName, oldAttributes, targetAttribute) => {
+export const reshuffleAttribute = (worldName, oldAttributes, targetAttribute) => {
     let world = {};
     switch (worldName) {
         case 'Cyberpunk':

--- a/src/character.js
+++ b/src/character.js
@@ -81,6 +81,7 @@ export const generateCharacter = (worldName) => {
             world = Asa;
     }
     const character = {
+        customAttributes: {},
         gender: chooseAttribute(world.gender),
         ancestry: chooseAttribute(world.ancestry),
         age: chooseAttribute(world.age),
@@ -100,6 +101,16 @@ export const generateCharacter = (worldName) => {
     character.personality2 = chooseAttribute(world.personality, [character.personality1.text], character.personality1.tags);
 
     return character;
+}
+
+export const setCustomAttribute = (character, customAttributeKey, customAttributeValue) => {
+    return {
+        ...character,
+        customAttributes: {
+            ...character.customAttributes,
+            [customAttributeKey]: customAttributeValue
+        }
+    }
 }
 
 export const reshuffle = (worldName, oldAttributes, targetAttribute) => {

--- a/src/character.js
+++ b/src/character.js
@@ -103,12 +103,14 @@ export const generateCharacter = (worldName) => {
     return character;
 }
 
-export const setCustomAttribute = (character, customAttributeKey, customAttributeValue) => {
+export const setCustomAttribute = (character, customAttributeKey, customAttributeValue) => { 
     return {
         ...character,
         customAttributes: {
             ...character.customAttributes,
-            [customAttributeKey]: customAttributeValue
+            [customAttributeKey]: customAttributeValue && customAttributeValue !== ''
+                ? customAttributeValue
+                : undefined
         }
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,8 @@ import { CharacterCard } from './character-card';
 
 import {
     generateCharacter,
-    reshuffle
+    reshuffle,
+    setCustomAttribute
 } from './character';
 
 class Board extends React.Component {
@@ -66,6 +67,16 @@ class Board extends React.Component {
         });
     }
 
+    setCustomAttribute(uid, customAttributeKey, customAttributeValue) {
+        this.setState({
+            characters: {
+                ...this.state.characters,
+                [uid]: setCustomAttribute(this.state.characters[uid], customAttributeKey, customAttributeValue)
+            }
+        })
+        console.log(arguments)
+    }
+
     handleWorldChange(event) {
         switch (event.target.value) {
             case 'Cyberpunk / Near Future':
@@ -86,19 +97,6 @@ class Board extends React.Component {
                 
                 return 'Asa (Homebrew Fantasy)';
         }
-    }
-
-    isAttributeGroupBeingEdited(attributeGroup) {
-        console.log(`${attributeGroup} is being edited: ${(this.state.attributeGroupBeingEdited === attributeGroup)}`);
-
-        return (this.state.attributeGroupBeingEdited === attributeGroup);
-    }
-
-    setAttributeGroupBeingEdited(attributeGroup) {
-        console.log(attributeGroup);
-        this.setState({
-            attributeGroupBeingEdited: attributeGroup
-        });
     }
 
     render() {
@@ -125,10 +123,9 @@ class Board extends React.Component {
                     .map(([uid, character]) => <CharacterCard
                         key={uid}
                         character={character}
-                        reshuffle={(attribute) => this.reshuffleAttribute(uid, attribute)}
+                        reshuffle={attribute => this.reshuffleAttribute(uid, attribute)}
+                        setCustomAttribute={(customAttributeKey, customAttributeValue) => this.setCustomAttribute(uid, customAttributeKey, customAttributeValue)}
                         deleteCharacter={() => this.deleteCharacter(uid)}
-                        isAttributeGroupBeingEdited={(attributeGroup) => this.isAttributeGroupBeingEdited(attributeGroup)}
-                        setAttributeGroupBeingEdited={(attributeGroup) => this.setAttributeGroupBeingEdited(attributeGroup)}
                     />)
                 }
             </BoardContainer> 

--- a/src/index.js
+++ b/src/index.js
@@ -1,149 +1,25 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import dedent from 'dedent';
-import copy from 'clipboard-copy';
+
 import './index.css';
-import ClipboardSolid from './icons/ClipboardSolid';
-import PenSolid from './icons/PenSolid';
+
 import UserPlusSolid from './icons/UserPlusSolid';
-import TrashSolid from './icons/TrashSolid';
 import {
-    AttributeGroup,
-    AttributeGroupLabel,
-    AttributeLabel,
-    AttributeList,
     BoardContainer,
-    CharacterCardColumn,
-    CharacterCardContainer,
-    CharacterCardRow,
-    CharacterCardToolbar,
     Label,
-    NameWrapper,
     Option,
-    ToolbarButton,
     TopToolbar,
     TopToolbarButton,
     TopToolbarColumn,
     Select,
     SelectContainer
-    } from './styles.js';
+} from './styles.js';
+import { CharacterCard } from './character-card';
+
 import {
     generateCharacter,
     reshuffle
 } from './character';
-
-function uppercaseFirstLetter(string) {
-
-    return string
-        ? string.charAt(0).toUpperCase() + string.slice(1)
-        : false;
-}
-
-function determinerBefore(string) {
-
-    return ['a', 'e', 'i', 'o', 'u'].includes(string.charAt(0)) ? 'an' : 'a';
-}
-
-function displayGender(age, gender) {
-
-    switch (gender) {
-        case 'cis male': return ['young', 'teenage'].includes(age) ? 'boy' : 'man';
-        case 'cis female': return ['young', 'teenage'].includes(age) ? 'girl' : 'woman';
-        case 'trans male': return ['young', 'teenage'].includes(age) ? 'trans boy' : 'trans man';
-        case 'trans female': return ['young', 'teenage'].includes(age) ? 'trans girl' : 'trans woman';
-        case 'genderfluid': return ['young', 'teenage'].includes(age) ? 'genderfluid child' : 'genderfluid person';
-        case 'agender': return ['young', 'teenage'].includes(age) ? 'agender child' : 'agender person';
-        default: return 'person';
-    }
-}
-
-function Attribute(props) {
-    return (
-        <AttributeLabel onClick={props.onClick}>{props.value}</AttributeLabel>
-    );
-}
-
-const CharacterCard = ({ deleteCharacter, reshuffle, character, isAttributeGroupBeingEdited, setAttributeGroupBeingEdited }) => {
-    return (
-        <CharacterCardContainer>
-            <CharacterCardToolbar>
-                <ToolbarButton onClick={() => copy(dedent(
-                        `${character.givenName.text} ${character.familyName.text}
-                        ${uppercaseFirstLetter(determinerBefore(character.age.text))} ${character.age.text} ${character.race.text} of ${character.ancestry.text} descent
-                        Job: ${character.competency.text} ${character.job.text}
-                        Appearance: ${character.appearance1.text}, ${character.appearance2.text}
-                        Mood: ${character.mood.text}
-                        Personality: ${character.personality1.text}, ${character.personality2.text}
-                        Life goal: ${character.motivation.text}
-                        Relationships: ${character.sexuality.text}, ${character.relationship.text}`
-                        ))}>
-                    <ClipboardSolid />
-                </ToolbarButton>
-                <ToolbarButton onClick={() => deleteCharacter()}>
-                    <TrashSolid />
-                </ToolbarButton>
-            </CharacterCardToolbar>
-            <NameWrapper>
-                <Attribute name='givenName' onClick={() => reshuffle('givenName')} value={character.givenName.text} />
-                {' '}
-                <Attribute name='familyName' onClick={() => reshuffle('familyName')} value={character.familyName.text} />
-            </NameWrapper>
-            <AttributeGroup>
-                {uppercaseFirstLetter(determinerBefore(character.age.text))}
-                {' '}
-                <Attribute name='age' onClick={() => reshuffle('age')} value={character.age.text} />
-                {' '}
-                <Attribute name='race' onClick={() => reshuffle('race')} value={character.race.text} />
-                {' '}
-                <Attribute name='gender' onClick={() => reshuffle('gender')} value={displayGender(character.age.text, character.gender.text)} />
-                {' '}
-                of <Attribute name='ancestry' onClick={() => reshuffle('ancestry')} value={character.ancestry.text} /> descent
-            </AttributeGroup>
-            <CharacterCardRow>
-                <CharacterCardColumn>
-                    <AttributeGroup isBeingEdited={isAttributeGroupBeingEdited('job')}>
-                        <AttributeGroupLabel onClick={() => setAttributeGroupBeingEdited('job')}>Job <PenSolid /></AttributeGroupLabel>
-                        <Attribute name='competency' onClick={() => reshuffle('competency')} value={uppercaseFirstLetter(character.competency.text)} />
-                        {' '}
-                        <Attribute name='job' onClick={() => reshuffle('job')} value={character.job.text} />
-                    </AttributeGroup>
-                    <AttributeGroup isBeingEdited={isAttributeGroupBeingEdited('appearance')}>
-                        <AttributeGroupLabel onClick={() => setAttributeGroupBeingEdited('appearance')}>Appearance <PenSolid /></AttributeGroupLabel>
-                        <Attribute name='appearance1' onClick={() => reshuffle('appearance1')} value={uppercaseFirstLetter(character.appearance1.text)} />,
-                        {' '}
-                        <Attribute name='appearance2' onClick={() => reshuffle('appearance2')} value={character.appearance2.text} />
-                    </AttributeGroup>
-                </CharacterCardColumn>
-                <CharacterCardColumn>
-                    <AttributeGroup isBeingEdited={isAttributeGroupBeingEdited('mood')}>
-                        <AttributeGroupLabel onClick={() => setAttributeGroupBeingEdited('mood')}>Mood <PenSolid /></AttributeGroupLabel>
-                        <Attribute name='mood' onClick={() => reshuffle('mood')} value={character.mood.text} />
-                    </AttributeGroup>
-                    <AttributeGroup isBeingEdited={isAttributeGroupBeingEdited('personality')}>
-                        <AttributeGroupLabel onClick={() => setAttributeGroupBeingEdited('personality')}>Personality <PenSolid /></AttributeGroupLabel>
-                        <Attribute name='personality1' onClick={() => reshuffle('personality1')} value={uppercaseFirstLetter(character.personality1.text)} /> and
-                        {' '}
-                        <Attribute name='personality2' onClick={() => reshuffle('personality2')} value={character.personality2.text} />
-                    </AttributeGroup>
-                </CharacterCardColumn>
-                <CharacterCardColumn>
-                    <AttributeGroup isBeingEdited={isAttributeGroupBeingEdited('motivation')}>
-                        <AttributeGroupLabel onClick={() => setAttributeGroupBeingEdited('motivation')}>Life goal <PenSolid /></AttributeGroupLabel>
-                        <Attribute name='motivation' onClick={() => reshuffle('motivation')} value={character.motivation.text} />
-                    </AttributeGroup>
-                    <AttributeGroup isBeingEdited={isAttributeGroupBeingEdited('relationships')}>
-                        <AttributeGroupLabel onClick={() => setAttributeGroupBeingEdited('relationships')}>Relationships <PenSolid /></AttributeGroupLabel>
-                        <AttributeList>
-                            <Attribute name='sexuality' onClick={() => reshuffle('sexuality')} value={uppercaseFirstLetter(character.sexuality.text)} />,
-                            {' '}
-                            <Attribute name='relationship' onClick={() => reshuffle('relationship')} value={character.relationship.text} />
-                        </AttributeList>
-                    </AttributeGroup>
-                </CharacterCardColumn>
-            </CharacterCardRow>
-        </CharacterCardContainer>
-    )
-}
 
 class Board extends React.Component {
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,38 +22,7 @@ import {
     setCustomAttribute
 } from './character';
 
-const attributeConfigs = new Map([
-    ['name', {
-        template: '%givenName% %familyName%'
-    }],
-    ['description', {
-        template: '%INDEFINITE_ARTICLE% %age% %race% %gender% of %ancestry% descent',
-    }],
-    ['job', {
-        template: '%competency% %job%',
-        label: 'job' 
-    }],
-    ['appearance', {
-        template: '%appearance1%, %appearance2%',
-        label: 'appearance' 
-    }],
-    ['mood', {
-        template: '%mood%',
-        label: 'mood' 
-    }],
-    ['personality', {
-        template: '%personality1% and %personality2%',
-        label: 'personality' 
-    }],
-    ['lifeGoal', {
-        template: '%motivation%',
-        label: 'life goal' 
-    }],
-    ['relationships', {
-        template: '%sexuality%, %relationship%',
-        label: 'relationships'
-    }]
-]);
+import { attributeConfigs } from './attribute-configs';
 
 class Board extends React.Component {
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,39 @@ import {
     setCustomAttribute
 } from './character';
 
+const attributeConfigs = new Map([
+    ['name', {
+        template: '%givenName% %familyName%'
+    }],
+    ['description', {
+        template: '%INDEFINITE_ARTICLE% %age% %race% %gender% of %ancestry% descent',
+    }],
+    ['job', {
+        template: '%competency% %job%',
+        label: 'job' 
+    }],
+    ['appearance', {
+        template: '%appearance1%, %appearance2%',
+        label: 'appearance' 
+    }],
+    ['mood', {
+        template: '%mood%',
+        label: 'mood' 
+    }],
+    ['personality', {
+        template: '%personality1% and %personality2%',
+        label: 'personality' 
+    }],
+    ['lifeGoal', {
+        template: '%motivation%',
+        label: 'life goal' 
+    }],
+    ['relationships', {
+        template: '%sexuality%, %relationship%',
+        label: 'relationships'
+    }]
+]);
+
 class Board extends React.Component {
 
     constructor(props) {
@@ -122,6 +155,7 @@ class Board extends React.Component {
                     .map(([uid, character]) => <CharacterCard
                         key={uid}
                         character={character}
+                        attributeConfigs={attributeConfigs}
                         reshuffleAttribute={attribute => this.reshuffleAttribute(uid, attribute)}
                         setCustomAttribute={(customAttributeKey, customAttributeValue) => this.setCustomAttribute(uid, customAttributeKey, customAttributeValue)}
                         deleteCharacter={() => this.deleteCharacter(uid)}

--- a/src/index.js
+++ b/src/index.js
@@ -49,33 +49,39 @@ class Board extends React.Component {
         });
     }
 
-    deleteCharacter(uid) {
-        const {
-            [uid]: removedCharacter,
-            ...newCharacters
-        } = this.state.characters;
-
-        this.setState({
-            characters: newCharacters
-        });
+    deleteCharacterHandler(uid) {
+        return () => {
+            const {
+                [uid]: removedCharacter,
+                ...newCharacters
+            } = this.state.characters;
+    
+            this.setState({
+                characters: newCharacters
+            });
+        }
     }
 
-    reshuffleAttribute(uid, attribute) {
-        this.setState({
-            characters: {
-                ...this.state.characters,
-                [uid]: reshuffleAttribute(this.state.worldName, this.state.characters[uid], attribute)
-            }
-        });
+    reshuffleAttributeHandler(uid) {
+        return attribute => {
+            this.setState({
+                characters: {
+                    ...this.state.characters,
+                    [uid]: reshuffleAttribute(this.state.worldName, this.state.characters[uid], attribute)
+                }
+            });
+        }
     }
 
-    setCustomAttribute(uid, customAttributeKey, customAttributeValue) {
-        this.setState({
-            characters: {
-                ...this.state.characters,
-                [uid]: setCustomAttribute(this.state.characters[uid], customAttributeKey, customAttributeValue)
-            }
-        })
+    setCustomAttributeHandler(uid) {
+        return (customAttributeKey, customAttributeValue) => {
+            this.setState({
+                characters: {
+                    ...this.state.characters,
+                    [uid]: setCustomAttribute(this.state.characters[uid], customAttributeKey, customAttributeValue)
+                }
+            })
+        }
     }
 
     handleWorldChange(event) {
@@ -125,9 +131,9 @@ class Board extends React.Component {
                         key={uid}
                         character={character}
                         attributeConfigs={attributeConfigs}
-                        reshuffleAttribute={attribute => this.reshuffleAttribute(uid, attribute)}
-                        setCustomAttribute={(customAttributeKey, customAttributeValue) => this.setCustomAttribute(uid, customAttributeKey, customAttributeValue)}
-                        deleteCharacter={() => this.deleteCharacter(uid)}
+                        reshuffleAttribute={this.reshuffleAttributeHandler(uid)}
+                        setCustomAttribute={this.setCustomAttributeHandler(uid)}
+                        deleteCharacter={this.deleteCharacterHandler(uid)}
                     />)
                 }
             </BoardContainer> 

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ import { CharacterCard } from './character-card';
 
 import {
     generateCharacter,
-    reshuffle,
+    reshuffleAttribute,
     setCustomAttribute
 } from './character';
 
@@ -62,7 +62,7 @@ class Board extends React.Component {
         this.setState({
             characters: {
                 ...this.state.characters,
-                [uid]: reshuffle(this.state.worldName, this.state.characters[uid], attribute)
+                [uid]: reshuffleAttribute(this.state.worldName, this.state.characters[uid], attribute)
             }
         });
     }
@@ -74,7 +74,6 @@ class Board extends React.Component {
                 [uid]: setCustomAttribute(this.state.characters[uid], customAttributeKey, customAttributeValue)
             }
         })
-        console.log(arguments)
     }
 
     handleWorldChange(event) {
@@ -123,7 +122,7 @@ class Board extends React.Component {
                     .map(([uid, character]) => <CharacterCard
                         key={uid}
                         character={character}
-                        reshuffle={attribute => this.reshuffleAttribute(uid, attribute)}
+                        reshuffleAttribute={attribute => this.reshuffleAttribute(uid, attribute)}
                         setCustomAttribute={(customAttributeKey, customAttributeValue) => this.setCustomAttribute(uid, customAttributeKey, customAttributeValue)}
                         deleteCharacter={() => this.deleteCharacter(uid)}
                     />)

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { darken } from 'polished';
 
-const colors = {
+export const colors = {
     bard: '#E052E0',
     clericRed: '#EB4747',
     druid: '#60DF20',
@@ -176,15 +176,6 @@ export const ToolbarButton = styled(Button)`
 
 export const ToolbarDeleteButton = styled.button``;
 
-
-export const AttributeGroup = styled.div`
-    ${props => props.isBeingEdited && `color: ${colors.clericRed};`}
-    
-    :not(:last-child) {
-        margin-bottom: 1.65rem;
-    }
-`;
-
 export const AttributeGroupLabel = styled.button`
     display: block;
     background-color: transparent;
@@ -230,13 +221,6 @@ export const AttributeLabel = styled.span`
         cursor: pointer;
         text-decoration: line-through;
     }
-`;
-
-export const AttributeList = styled.ul`
-    margin-top: 0;
-    margin-bottom: 0;
-    padding-left: 0;
-    list-style-type: none;
 `;
 
 export const NameWrapper = styled.h1`

--- a/src/styles.js
+++ b/src/styles.js
@@ -214,15 +214,6 @@ export const AttributeGroupLabel = styled.button`
     }
 `;
 
-export const AttributeLabel = styled.span`
-
-    :hover {
-        color: #999;
-        cursor: pointer;
-        text-decoration: line-through;
-    }
-`;
-
 export const NameWrapper = styled.h1`
     font-size: 1.5rem;
     margin-top: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6104,7 +6104,7 @@ react-error-overlay@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.1.tgz#417addb0814a90f3a7082eacba7cee588d00da89"
 
-react-is@^16.6.0, react-is@^16.8.1:
+react-is@^16.6.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
 
@@ -6151,6 +6151,16 @@ react-scripts@1.1.1:
     whatwg-fetch "2.0.3"
   optionalDependencies:
     fsevents "^1.1.3"
+
+react-test-renderer@^16.12.0:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.12.0.tgz#11417ffda579306d4e841a794d32140f3da1b43f"
+  integrity sha512-Vj/teSqt2oayaWxkbhQ6gKis+t5JrknXfPVo+aIJ8QwYAqMPH77uptOdrlphyxl8eQI/rtkOYg86i/UWkpFu0w==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.8.6"
+    scheduler "^0.18.0"
 
 react@^16.2.0:
   version "16.12.0"


### PR DESCRIPTION
Ta-daa! 
`customAttributes` are added to character models - these can be saved with characters.

If a custom attribute is defined, it will render as an editable field. If not, a template is used to render an `AttributeGroup` (the same template can be rendered as a string, or any other format, if needed in the future - it's currently being used for the text copied to the clipboard, too).

How editing works currently: if the pen icon is clicked, the `AttributeGroup` is replaced with an editable html element, its contents set to the same value as the generated attribute descriptions. Changes are only saved when the field loses focus (`onBlur` handler, when you click away, for example). To revert to the generated versions, simply delete all text in the field and save (by clicking away).

Not much cross-browser testing was done, I'd use [a readily available coponent](https://www.npmjs.com/package/react-contenteditable) for the editable fields instead of the current - very basic - implementation to iron out bugs (like the cursor jumping to the wrong end of the field). I didn't dive too much into this, because I'm not sure about the intended UX. If a rerender is triggered while a field is edited, changes will be lost. The `editMode` state is buggy, it will be set to true only when the pen icon was clicked, not when the field itseld becomes focused.